### PR TITLE
Update gingersnaps.rnc

### DIFF
--- a/Relax NG Exercises/Exercise 4/gingersnaps.rnc
+++ b/Relax NG Exercises/Exercise 4/gingersnaps.rnc
@@ -12,9 +12,7 @@ cooking_time = element cooking_time {text}
 total_time = element total_time {text}
 servingsize = element servingsize {text}
 heading = element heading {text,id}
-id = attribute id {xsd:float | "VS" | "GS" | "salt" | "BKS" | "molasses" | "APflour" | "ginger" | "cloves" | "cinnamon" | "mixture" | "placing"} 
-
-
+id = attribute id {xsd:float | "VS" | "GS" | "salt" | "BKS" | "molasses" | "APflour" | "ginger" | "cloves" | "cinnamon" | "mixture" | "placing"}
 recipe = element recipe {listingred, instrc}
 
 listingred = element listingred {ingred+, QnA, ingredtwo}


### PR DESCRIPTION
@JiminyKricket0323 You had a stray asterisk sitting at the end of the definition of the id attribute. That was breaking the form of the Relax NG and preventing it from reading the next line, which is your definition of the recipe element. So this is just a quick repair.

The Relax NG will now be valid, though it does not validate your XML at this point. 